### PR TITLE
fix: update SERVER_IMAGE variable to use dynamic versioning

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -85,7 +85,7 @@ done
 
 # Set final configuration based on arguments
 export COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME"
-export SERVER_IMAGE="99xio/xiansai-server:local"
+export SERVER_IMAGE="99xio/xiansai-server:$VERSION"
 export UI_IMAGE="99xio/xiansai-ui:$VERSION"
 
 echo "📋 Configuration:"


### PR DESCRIPTION
- Changed SERVER_IMAGE in start-all.sh to reference the VERSION variable for better flexibility in image management.