### PR TITLE
Converted all scripts to use LF instead of CRLF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Using CRLF is problematic on Unix based systems as they use \n for line endings instead of \r on NT based systems. added git attribute files to force this change